### PR TITLE
Added slurmrestd required Auth options for slurmdbd

### DIFF
--- a/manifests/dbnode/config.pp
+++ b/manifests/dbnode/config.pp
@@ -23,6 +23,8 @@ class slurm::dbnode::config (
   Optional[String] $dbd_backup_host = undef,
   Integer[0] $dbd_port = $slurm::config::accounting_storage_port,
   Enum['auth/none','auth/munge'] $auth_type = 'auth/none',
+  Optional[Array[String]] $auth_alt_type = $slurm::config::auth_alt_type,
+  Optional[Array[String]] $auth_alt_parameters = $slurm::config::auth_alt_parameters,
   Optional[String] $auth_info = undef,
   Optional[String] $default_qos = undef,
   Integer[0] $message_timeout = 10,

--- a/templates/slurmdbd.conf.erb
+++ b/templates/slurmdbd.conf.erb
@@ -24,6 +24,8 @@ DbdPort=<%= @dbd_port %>
 
 # SECURITY
 AuthType=<%= @auth_type %>
+<%= @auth_alt_type.nil? ? '#AuthAltTypes=' : ( 'AuthAltTypes=' + @auth_alt_type.join(',')) %>
+<%= @auth_alt_parameters.nil? ? '#AuthAltParameters=' : ( 'AuthAltParameters=' + @auth_alt_parameters.join(',')) %>
 <%= @auth_info.nil? ? '#AuthInfo=' : ('AuthInfo=' + @auth_info) %>
 
 


### PR DESCRIPTION
When using slurmrestd and authentication through JWT, some options are necessary.