### PR TITLE
Added Include option for slurm.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -246,7 +246,8 @@ class slurm::config (
 
   Boolean $open_firewall = false,
   Array[String] $munge_packages = $slurm::params::munge_packages,
-
+  Optional[String] $include_file = undef,
+  Boolean $include_only = false,
 ) inherits slurm::params {
 
   # The following variables are version dependent

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -15,6 +15,10 @@
 #
 # Configuration file containing common parameters for headnode and workernode.
 #
+<% if @include_file -%>
+Include <%= @include_file %>
+<% end -%>
+<% if @include_only == false -%>
 
 # GENERAL OPTIONS
 AllowSpecResourcesUsage=<%= @allow_spec_resources_usage %>
@@ -423,4 +427,5 @@ TreeWidth=<%= @tree_width %>
 # PARTITIONS
 <% @partitions.each do |partition| -%>
 <%= partition.map{|pair| pair.join('=')}.join(' ') %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
The include option is missing from the current puppet code. This pull request adds it.
From the man page:
If a line begins with the word "Include" followed by whitespace and then a file name, that file will be included inline with the current configuration file.  For large or complex systems, multiple configuration files may prove easier to manage and enable reuse of some files (See INCLUDE MODIFIERS for more details).
