### PR TITLE
Workernode list: accepting 0-length list

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -240,7 +240,7 @@ class slurm::config (
   String $route_plugin = 'route/default',
   Integer[1] $tree_width = 50,
 
-  Optional[Array[Hash,1]] $workernodes = undef, 
+  Optional[Array[Hash,0]] $workernodes = undef, 
   Optional[Array[Hash,1]] $nodesets = undef,
   Optional[Array[Hash,1]] $partitions = undef,
   Optional[Array[Hash,1]] $gres_definitions = undef,


### PR DESCRIPTION
This changes allows empty workernodes list. This is necessary for having a complete dynamic cluster with no initial nodes defined.